### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Usage
 ---
-
+[![Run on Repl.it](https://repl.it/badge/github/MasterGlasses76/altTools)](https://repl.it/github/MasterGlasses76/altTools)
 ##### Class `altTools`
 `write(value, pause=0.06, newline=True)` Prints out values to the stream and pauses shortly between each value to create a typewriter effect. ***Limitations in coding enviorments can lead to inconsistencies**
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).